### PR TITLE
feat(TA-1696): set cors allow credentials optionally

### DIFF
--- a/lib/authenticated-api/authenticated-api-props.ts
+++ b/lib/authenticated-api/authenticated-api-props.ts
@@ -19,6 +19,7 @@ export interface AuthenticatedApiProps {
   domainName: string;
   certificateArn: string;
   corsDomain?: string[];
+  corsAllowCredentials?: boolean;
 
   // Access logs via CloudWatch log group
   logging?: {

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -55,7 +55,7 @@ export class AuthenticatedApi extends Construct {
         corsPreflight: {
           allowHeaders: ["*"],
           allowMethods: [apigatewayv2_alpha.CorsHttpMethod.ANY],
-          allowCredentials: true,
+          allowCredentials: props.corsAllowCredentials ?? true,
           allowOrigins: props.corsDomain,
         },
       }),

--- a/test/infra/authenticated-api/authenticated-api.test.ts
+++ b/test/infra/authenticated-api/authenticated-api.test.ts
@@ -99,6 +99,15 @@ describe("AuthenticatedApi", () => {
         {
           Name: "test-MyTestAuthenticatedApi",
           ProtocolType: "HTTP",
+          CorsConfiguration: {
+            AllowCredentials: true,
+            AllowHeaders: ["*"],
+            AllowMethods: ["*"],
+            AllowOrigins: [
+              "http://localhost:4200",
+              `https://test-simple-authenticated-api.talis.com`,
+            ],
+          },
         },
       );
     });


### PR DESCRIPTION
* [TA-1696](https://techfromsage.atlassian.net/browse/TA-1696)

**Description**
talis-cdk-constructs hard codes the value of the CORS header `access-control-allow-credentials` to `true`. We have a requirement in the new extension to wildcard `access-allow-origins` however, when `access-control-allow-credentials` value is true, AWS API Gateway will not allow you to wildcard the origins. We therefore need to be able to set `access-control-allow-credentials` to false so that we can wildcard the origin.

[TA-1696]: https://techfromsage.atlassian.net/browse/TA-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ