### PR TITLE
feat: set maxConcurrency on LambdaWorker DLQ

### DIFF
--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -148,6 +148,7 @@ export class LambdaWorker extends Construct {
       new SqsEventSource(lambdaDLQ, {
         enabled: false,
         batchSize: 1,
+        maxConcurrency: props.lambdaProps.queueMaxConcurrency,
       }),
     );
 

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -105,6 +105,30 @@ describe("LambdaWorker", () => {
         });
       });
 
+      test("provisions Lambda EventSourceMapping", () => {
+        Template.fromStack(stack).hasResourceProperties(
+          "AWS::Lambda::EventSourceMapping",
+          {
+            Enabled: true,
+            BatchSize: 1,
+            ScalingConfig: {
+              MaximumConcurrency: 5,
+            },
+          },
+        );
+
+        Template.fromStack(stack).hasResourceProperties(
+          "AWS::Lambda::EventSourceMapping",
+          {
+            Enabled: false,
+            BatchSize: 1,
+            ScalingConfig: {
+              MaximumConcurrency: 5,
+            },
+          },
+        );
+      });
+
       test("provisions three alarms", () => {
         Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 3);
       });


### PR DESCRIPTION
https://techfromsage.atlassian.net/browse/PLT-1141

Problem:  when replaying messages in bulk, the number of concurrent lambda’s are not controlled and this can result in a flood of concurrent lambda’s

Solution: We set the max concurrency on the lambda workers SQS trigger for the main queue. We should set the same value on the DLQ trigger.