### PR TITLE
feat: make securityPolicy configurable on CdnSiteHostingConstruct

### DIFF
--- a/examples/simple-cdn-site-hosting-construct/lib/simple-cdn-site-hosting-construct-stack.ts
+++ b/examples/simple-cdn-site-hosting-construct/lib/simple-cdn-site-hosting-construct-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from "aws-cdk-lib";
+import { aws_cloudfront as cloudfront } from "aws-cdk-lib";
 import { aws_s3_deployment as s3deploy } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as path from "path";
@@ -39,6 +40,7 @@ export class SimpleCdnSiteHostingConstructStack extends cdk.Stack {
         ],
         websiteIndexDocument: "index.html",
         certificateArn: STAGING_TALIS_IO_TLS_CERT_ARN,
+        securityPolicyProtocol: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       },
     );
 

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -38,8 +38,8 @@ export class CdnSiteHostingConstruct extends Construct {
 
     const aliases = getAliases(props);
 
-    const securityPolicProtocol = props.SecurityPolicyProtocol
-      ? props.SecurityPolicyProtocol
+    const securityPolicProtocol = props.securityPolicyProtocol
+      ? props.securityPolicyProtocol
       : cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016;
 
     // certificate

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -38,6 +38,8 @@ export class CdnSiteHostingConstruct extends Construct {
 
     const aliases = getAliases(props);
 
+    const securityPolicProtocol = props.SecurityPolicyProtocol? props.SecurityPolicyProtocol : cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016;
+
     // certificate
     const viewerCertificate = cloudfront.ViewerCertificate.fromAcmCertificate(
       certificatemanager.Certificate.fromCertificateArn(
@@ -48,7 +50,7 @@ export class CdnSiteHostingConstruct extends Construct {
       {
         aliases: [siteDomain, ...aliases],
         sslMethod: cloudfront.SSLMethod.SNI,
-        securityPolicy: cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016,
+        securityPolicy: securityPolicProtocol,
       },
     );
 

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -38,7 +38,9 @@ export class CdnSiteHostingConstruct extends Construct {
 
     const aliases = getAliases(props);
 
-    const securityPolicProtocol = props.SecurityPolicyProtocol? props.SecurityPolicyProtocol : cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016;
+    const securityPolicProtocol = props.SecurityPolicyProtocol
+      ? props.SecurityPolicyProtocol
+      : cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016;
 
     // certificate
     const viewerCertificate = cloudfront.ViewerCertificate.fromAcmCertificate(

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -19,5 +19,5 @@ export interface CommonCdnSiteHostingProps {
   sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
   websiteErrorDocument?: string;
   websiteIndexDocument: string;
-  SecurityPolicyProtocol?: cloudfront.SecurityPolicyProtocol;
+  securityPolicyProtocol?: cloudfront.SecurityPolicyProtocol;
 }

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -1,4 +1,5 @@
 import * as cdk from "aws-cdk-lib";
+import { aws_cloudfront as cloudfront } from "aws-cdk-lib";
 import { aws_s3_deployment as s3deploy } from "aws-cdk-lib";
 
 export interface SourcesWithDeploymentOptions {
@@ -18,4 +19,5 @@ export interface CommonCdnSiteHostingProps {
   sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
   websiteErrorDocument?: string;
   websiteIndexDocument: string;
+  SecurityPolicyProtocol?: cloudfront.SecurityPolicyProtocol;
 }

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -331,7 +331,7 @@ describe("CdnSiteHostingConstruct", () => {
         sources: [s3deploy.Source.asset("./")],
         websiteErrorDocument: "error.html",
         websiteIndexDocument: "index.html",
-        securityPolicyProtocol: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2018,
+        securityPolicyProtocol: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       });
     });
 
@@ -348,7 +348,7 @@ describe("CdnSiteHostingConstruct", () => {
             DefaultRootObject: "index.html",
             ViewerCertificate: {
               AcmCertificateArn: fakeCertificateArn,
-              MinimumProtocolVersion: "TLSv1.2_2018",
+              MinimumProtocolVersion: "TLSv1.2_2021",
               SslSupportMethod: "sni-only",
             },
             Origins: [


### PR DESCRIPTION
- https://techfromsage.atlassian.net/browse/PLT-1403

In order to make a consumer of the CDN Site Hosting Construct (OTIS) TLS 1.2, this PR allows the security policy protocol to be set.

So the behavior does not change, the default remains `TLS_V1_1_2016` but this can now be overridden in the props.

## Testing

The Infra Unit tests now check for the minimum TLS version.

The integration tests deploy cdn site constructs which both have the default and override it.

#### Default

![image](https://github.com/user-attachments/assets/943d38c4-da0e-48ee-9437-de3692d0d3a6)

#### Override

![image](https://github.com/user-attachments/assets/2215e1b4-b16a-434f-9923-d822bbd7900f)

