### PR TITLE
feat: allow custom NodejsFunction runtime

### DIFF
--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -1,8 +1,18 @@
 import * as cdk from "aws-cdk-lib";
 import { aws_ec2 as ec2 } from "aws-cdk-lib";
-import { BundlingOptions } from "aws-cdk-lib/aws-lambda-nodejs";
+import { aws_lambda_nodejs as lambda_nodejs } from "aws-cdk-lib";
 
-export interface AuthenticatedApiFunctionProps {
+export interface AuthenticatedApiFunctionProps
+  extends Pick<
+    lambda_nodejs.NodejsFunctionProps,
+    | "entry"
+    | "handler"
+    | "runtime"
+    | "awsSdkConnectionReuse"
+    | "depsLockFilePath"
+    | "bundling"
+    | "projectRoot"
+  > {
   name: string;
   entry: string;
   environment?: { [key: string]: string };
@@ -12,5 +22,6 @@ export interface AuthenticatedApiFunctionProps {
   vpcSubnets?: ec2.SubnetSelection;
   securityGroups?: Array<ec2.ISecurityGroup>;
   memorySize?: number;
-  bundling?: BundlingOptions;
+  /** @default true */
+  awsSdkConnectionReuse?: boolean;
 }

--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -22,22 +22,24 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
 
     super(scope, id, {
       functionName: `${props.name}`,
-      entry: props.entry,
       environment: buildLambdaEnvironment({
         environment: props.environment,
         timeout: props.timeout,
       }),
-      handler: props.handler,
       memorySize: props.memorySize ?? MINIMUM_MEMORY_SIZE,
-
-      // Enforce the following properties
-      awsSdkConnectionReuse: true,
-      runtime: lambda.Runtime.NODEJS_18_X,
       timeout: props.timeout,
       securityGroups: props.securityGroups,
       vpc: props.vpc,
       vpcSubnets: props.vpcSubnets,
+
+      // NodejsFunction-only props
+      entry: props.entry,
+      handler: props.handler,
+      runtime: props.runtime ?? lambda.Runtime.NODEJS_18_X,
+      awsSdkConnectionReuse: props.awsSdkConnectionReuse ?? true,
       bundling: props.bundling,
+      depsLockFilePath: props.depsLockFilePath,
+      projectRoot: props.projectRoot,
     });
   }
 }

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -3,11 +3,24 @@ import { aws_ec2 as ec2 } from "aws-cdk-lib";
 import { aws_iam as iam } from "aws-cdk-lib";
 import { aws_sns as sns } from "aws-cdk-lib";
 import { aws_lambda as lambda } from "aws-cdk-lib";
+import { aws_lambda_nodejs as lambda_nodejs } from "aws-cdk-lib";
 
 // Lambda properties for different runtimes
-export interface FunctionLambdaProps {
+export interface FunctionLambdaProps
+  extends Pick<
+    lambda_nodejs.NodejsFunctionProps,
+    | "entry"
+    | "handler"
+    | "runtime"
+    | "awsSdkConnectionReuse"
+    | "depsLockFilePath"
+    | "bundling"
+    | "projectRoot"
+  > {
   handler: string;
   entry: string;
+  /** @default true */
+  awsSdkConnectionReuse?: boolean;
 }
 
 export interface ContainerFromEcrLambdaProps {

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -277,8 +277,6 @@ export class LambdaWorker extends Construct {
 
       // Pass through props from lambda props object
       // Documented here https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-nodejs.NodejsFunctionProps.html
-      entry: props.lambdaProps.entry,
-      handler: props.lambdaProps.handler,
       description: props.lambdaProps.description,
       environment: buildLambdaEnvironment({
         environment: props.lambdaProps.environment,
@@ -295,9 +293,14 @@ export class LambdaWorker extends Construct {
       vpcSubnets: props.lambdaProps.vpcSubnets,
       filesystem: props.lambdaProps.filesystem,
 
-      // Enforce the following properties
-      awsSdkConnectionReuse: true,
-      runtime: lambda.Runtime.NODEJS_18_X,
+      // NodejsFunction-only props
+      entry: props.lambdaProps.entry,
+      handler: props.lambdaProps.handler,
+      runtime: props.lambdaProps.runtime ?? lambda.Runtime.NODEJS_18_X,
+      awsSdkConnectionReuse: props.lambdaProps.awsSdkConnectionReuse ?? true,
+      depsLockFilePath: props.lambdaProps.depsLockFilePath,
+      bundling: props.lambdaProps.bundling,
+      projectRoot: props.lambdaProps.projectRoot,
     });
   }
 

--- a/test/infra/authenticated-api/authenticated-api.test.ts
+++ b/test/infra/authenticated-api/authenticated-api.test.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { aws_ec2 as ec2 } from "aws-cdk-lib";
 import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
 import { aws_sns as sns } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
 import { Template, Match } from "aws-cdk-lib/assertions";
 import * as path from "path";
 
@@ -41,12 +42,21 @@ describe("AuthenticatedApi", () => {
         `test-simple-authenticated-api-route2-handler`,
         {
           name: `test-route2-handler`,
-          entry: `${path.resolve(__dirname)}/routes/route2.js`,
           environment: {},
-          handler: "route",
           timeout: cdk.Duration.seconds(30),
           securityGroups: [],
           vpc: vpc,
+
+          // NodejsFunction props
+          entry: path.resolve(__dirname, "routes/route2.js"),
+          handler: "route",
+          projectRoot: path.resolve(__dirname, "../../.."),
+          depsLockFilePath: "package-lock.json",
+          runtime: lambda.Runtime.NODEJS_20_X,
+          awsSdkConnectionReuse: false,
+          bundling: {
+            minify: true,
+          },
         },
       );
 
@@ -171,7 +181,7 @@ describe("AuthenticatedApi", () => {
         FunctionName: "test-route2-handler",
         Timeout: 30,
         Handler: "index.route",
-        Runtime: "nodejs18.x",
+        Runtime: "nodejs20.x",
         Environment: {
           Variables: {
             LAMBDA_EXECUTION_TIMEOUT: "30",


### PR DESCRIPTION
`nodejs18.x` Lambda runtime is going to be deprecated on Sep 1, 2025. To make upgrades easier, we should allow CDK apps to specify their own runtime version, rather than imposing one.

This PR makes constructs that use NodejsFunction construct expose additional props: `runtime`, `awsSdkConnectionReuse`, `depsLockFilePath`, `bundling`, `projectRoot`.

These are non-breaking changes. For backwards compatibility, we're keeping `runtime` defaulting to `nodejs18.x`, and `awsSdkConnectionReuse` defaulting to `true`. However, it should be noted, connection reuse setting has no real effect where AWS SDK v3 is used. The `AWS_NODEJS_CONNECTION_REUSE_ENABLED` environment variable does not exist in the AWS SDK for JavaScript v3 but clients [reuse connections by default](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html).

In the next PR, we should introduce breaking changes:

- Bump authoriser Lambda to `nodejs22.x` or `nodejs20.x`.
- Remove the default `true` from `awsSdkConnectionReuse`.