### PR TITLE
feat: correct authorizer include .ts -> .js

### DIFF
--- a/lib/authenticated-rest-api/authenticated-rest-api.ts
+++ b/lib/authenticated-rest-api/authenticated-rest-api.ts
@@ -84,7 +84,7 @@ export class AuthenticatedRestApi extends Construct {
       {
         functionName: `${apiName}-authoriser`,
 
-        entry: `${path.resolve(__dirname)}/../../src/lambda/rest-api/authorizer.ts`,
+        entry: `${path.resolve(__dirname)}/../../src/lambda/rest-api/authorizer.js`,
         handler: "validateToken",
 
         bundling: {


### PR DESCRIPTION
- https://techfromsage.atlassian.net/browse/PLT-1355

In PR https://github.com/techfromsage/talis-cdk-constructs/pull/98 a new Authenticated Rest API was added.

Using the released version of the library fails because the construct is referencing the typescript file for the authoriser, not the javascript file:

```
Error: Cannot find entry file at /home/circleci/repo/node_modules/talis-cdk-constructs/lib/authenticated-rest-api/../../src/lambda/rest-api/authorizer.ts
```

This PR corrects the new construct to reference the built javascript file included in the release. This is in line with the other constructs, referencing the javascript file of source code, not the typescript file.

