### PR TITLE
feat: expose main queue from lambda worker

### DIFF
--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -35,9 +35,9 @@ export class LambdaWorker extends Construct {
 
   // Expose a reference to the SQS queue that this LambdaWorker
   // Obtaining a reference to the queue using the ARN exposed above
-  // allows for an unmodifiable reference to the queue to be obtained using 
+  // allows for an unmodifiable reference to the queue to be obtained using
   // findByArn. Direct access to the queue is provided to allow modification
-  // of the queue, for example for EventBridge iam permissions. 
+  // of the queue, for example for EventBridge iam permissions.
   public readonly lambdaQueue: sqs.Queue;
 
   constructor(scope: Construct, id: string, props: LambdaWorkerProps) {


### PR DESCRIPTION
- https://techfromsage.atlassian.net/browse/PLT-1454

This PR exposes the main sqs queue for the lambda worker as a readonly public property. This is needed if changes are required to the queue. 

Previously it has not been exposed, so that unwanted changes could not be made, allowing the construct to enforce things like retention period and visibility timeouts. 

However, to use this worker with EventBridge, we need access to the queue to set up IAM Policies. We have decided to expose the queue so that the user can do this externally to the construct rather than implement a mechanism within the construct to support EventBridge. This does mean the queue is exposed and settings on the queue COULD be overridden.

We are not exposing the DLQ at this point in time. This is internal to the worker and does not need to be exposed.