### PR TITLE
feat!: make node runtimes required lambda property

### DIFF
--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 // import { aws_ec2 as ec2 } from "aws-cdk-lib";
 import { aws_s3 as s3 } from "aws-cdk-lib";
 import { aws_sns as sns } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
 import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
 import { Construct } from "constructs";
 
@@ -28,7 +29,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     const alarmTopic = new sns.Topic(
       this,
       `${prefix}simple-authenticated-api-alarm`,
-      { topicName: `${prefix}simple-authenticated-api-alarm` },
+      { topicName: `${prefix}simple-authenticated-api-alarm` }
     );
 
     // VPC is optional. To use one, you would look it up as follows:
@@ -67,12 +68,13 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
         // A VPC is optional. If you need to specify one, you would do so here:
         // vpc: vpc,
         // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
-      },
+      }
     );
 
     const route2Handler = new AuthenticatedApiFunction(
@@ -84,12 +86,13 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
         // A VPC is optional. If you need to specify one, you would do so here:
         // vpc: vpc,
         // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
-      },
+      }
     );
 
     const route3Handler = new AuthenticatedApiFunction(
@@ -101,9 +104,10 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
-      },
+      }
     );
 
     const route4Handler = new AuthenticatedApiFunction(
@@ -115,9 +119,10 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
-      },
+      }
     );
 
     const api = new AuthenticatedApi(
@@ -178,7 +183,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
             requiredScope: "analytics:admin",
           },
         ],
-      },
+      }
     );
 
     // It's common to want to route to static content, for example api documentation.
@@ -199,7 +204,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         publicReadAccess: true,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
         websiteIndexDocument: "index.html",
-      },
+      }
     );
 
     // Url Routes can be added in the initial props of the api construct, but they can also be
@@ -213,7 +218,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
 
     console.log(`Regional domain name: ${api.domainName.regionalDomainName}`);
     console.log(
-      `Regional hosted zone id: ${api.domainName.regionalHostedZoneId}`,
+      `Regional hosted zone id: ${api.domainName.regionalHostedZoneId}`
     );
   }
 }

--- a/examples/simple-authenticated-rest-api/lib/simple-authenticated-rest-api-stack.ts
+++ b/examples/simple-authenticated-rest-api/lib/simple-authenticated-rest-api-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { aws_sns as sns } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import {
@@ -26,7 +27,7 @@ export class SimpleAuthenticatedRestApiStack extends cdk.Stack {
     const alarmTopic = new sns.Topic(
       this,
       `${prefix}simple-authenticated-rest-api-alarm`,
-      { topicName: `${prefix}simple-authenticated-rest-api-alarm` },
+      { topicName: `${prefix}simple-authenticated-rest-api-alarm` }
     );
 
     // VPC is optional. To use one, you would look it up as follows:
@@ -65,12 +66,13 @@ export class SimpleAuthenticatedRestApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
         // A VPC is optional. If you need to specify one, you would do so here:
         // vpc: vpc,
         // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
-      },
+      }
     );
 
     const route2Handler = new AuthenticatedRestApiFunction(
@@ -82,12 +84,13 @@ export class SimpleAuthenticatedRestApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
         // A VPC is optional. If you need to specify one, you would do so here:
         // vpc: vpc,
         // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
-      },
+      }
     );
 
     const route3Handler = new AuthenticatedRestApiFunction(
@@ -99,9 +102,10 @@ export class SimpleAuthenticatedRestApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
-      },
+      }
     );
 
     const route4Handler = new AuthenticatedRestApiFunction(
@@ -113,9 +117,10 @@ export class SimpleAuthenticatedRestApiStack extends cdk.Stack {
         environment: {},
         handler: "route",
         timeout: cdk.Duration.seconds(30),
+        runtime: lambda.Runtime.NODEJS_22_X,
         // A security group is optional. If you need to specify one, you would do so here:
         // securityGroups: lambdaSecurityGroups,
-      },
+      }
     );
 
     new AuthenticatedRestApi(this, `${prefix}simple-authenticated-rest-api`, {

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -3,6 +3,7 @@ import * as cdk from "aws-cdk-lib";
 import { aws_iam as iam } from "aws-cdk-lib";
 import { aws_sns as sns } from "aws-cdk-lib";
 import { aws_sqs as sqs } from "aws-cdk-lib";
+import { aws_lambda as lambda } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import { LambdaWorker } from "../../../lib";
@@ -36,7 +37,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
     const alarmTopic = new sns.Topic(
       this,
       `${prefix}simple-lambda-Worker-alarm`,
-      { topicName: `${prefix}simple-lambda-worker-alarm` },
+      { topicName: `${prefix}simple-lambda-worker-alarm` }
     );
 
     // VPC is optional. To use one, you would look it up as follows:
@@ -87,6 +88,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
           },
           entry: "src/lambda/simple-worker.js",
           handler: "simpleLambdaWorker",
+          runtime: lambda.Runtime.NODEJS_22_X,
           memorySize: 1024,
           // A security group is optional. If you need to specify one, you would do so here:
           // securityGroups: lambdaSecurityGroups,
@@ -129,7 +131,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
             }),
           },
         },
-      },
+      }
     );
   }
 }

--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -24,4 +24,5 @@ export interface AuthenticatedApiFunctionProps
   memorySize?: number;
   /** @default true */
   awsSdkConnectionReuse?: boolean;
+  runtime: cdk.aws_lambda.Runtime;
 }

--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -12,11 +12,11 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
   constructor(
     scope: Construct,
     id: string,
-    props: AuthenticatedApiFunctionProps,
+    props: AuthenticatedApiFunctionProps
   ) {
     if (props.memorySize && props.memorySize < MINIMUM_MEMORY_SIZE) {
       cdk.Annotations.of(scope).addError(
-        `lambda memory of ${props.memorySize} is less than the recommended size of ${MINIMUM_MEMORY_SIZE}`,
+        `lambda memory of ${props.memorySize} is less than the recommended size of ${MINIMUM_MEMORY_SIZE}`
       );
     }
 
@@ -35,7 +35,7 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
       // NodejsFunction-only props
       entry: props.entry,
       handler: props.handler,
-      runtime: props.runtime ?? lambda.Runtime.NODEJS_18_X,
+      runtime: props.runtime,
       awsSdkConnectionReuse: props.awsSdkConnectionReuse ?? true,
       bundling: props.bundling,
       depsLockFilePath: props.depsLockFilePath,

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -35,7 +35,7 @@ export class AuthenticatedApi extends Construct {
       (!props.domainName && props.certificateArn)
     ) {
       cdk.Annotations.of(scope).addError(
-        `To use a custom domain name both certificateArn and domainName must be specified`,
+        `To use a custom domain name both certificateArn and domainName must be specified`
       );
     }
     this.domainName = new apigatewayv2.DomainName(this, "domain-name", {
@@ -43,7 +43,7 @@ export class AuthenticatedApi extends Construct {
       certificate: acm.Certificate.fromCertificateArn(
         this,
         "cert",
-        props.certificateArn,
+        props.certificateArn
       ),
     });
     const apiName = `${props.prefix}${props.name}`;
@@ -175,12 +175,12 @@ export class AuthenticatedApi extends Construct {
         }),
 
         awsSdkConnectionReuse: true,
-        runtime: lambda.Runtime.NODEJS_18_X,
+        runtime: lambda.Runtime.NODEJS_22_X,
         timeout: authLambdaTimeout,
         securityGroups: props.securityGroups,
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets,
-      },
+      }
     );
 
     this.authorizer = new authorizers.HttpLambdaAuthorizer(
@@ -189,7 +189,7 @@ export class AuthenticatedApi extends Construct {
       {
         authorizerName: `${apiName}-http-lambda-authoriser`,
         responseTypes: [authorizers.HttpLambdaResponseType.SIMPLE], // Define if returns simple and/or iam response
-      },
+      }
     );
 
     if (props.urlRoutes) {
@@ -202,7 +202,7 @@ export class AuthenticatedApi extends Construct {
       for (const routeProps of props.lambdaRoutes) {
         const integration = new integrations.HttpLambdaIntegration(
           "http-lambda-integration",
-          routeProps.lambda,
+          routeProps.lambda
         );
 
         if (routeProps.isPublic === true) {
@@ -248,7 +248,7 @@ export class AuthenticatedApi extends Construct {
             // Set treatMissingData to IGNORE
             // Stops alarms with minimal data having false alarms when they transition to this state
             treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-          },
+          }
         );
         durationAlarm.addAlarmAction(this.alarmAction);
         durationAlarm.addOkAction(this.alarmAction);
@@ -272,7 +272,7 @@ export class AuthenticatedApi extends Construct {
             // Set treatMissingData to IGNORE
             // Stops alarms with minimal data having false alarms when they transition to this state
             treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-          },
+          }
         );
         errorsAlarm.addAlarmAction(this.alarmAction);
         errorsAlarm.addOkAction(this.alarmAction);
@@ -304,7 +304,7 @@ export class AuthenticatedApi extends Construct {
         // Set treatMissingData to IGNORE
         // Stops alarms with minimal data having false alarms when they transition to this state
         treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-      },
+      }
     );
     routeLatencyAlarm.addAlarmAction(this.alarmAction);
     routeLatencyAlarm.addOkAction(this.alarmAction);
@@ -319,7 +319,7 @@ export class AuthenticatedApi extends Construct {
         routeProps.baseUrl,
         {
           method: routeProps.method,
-        },
+        }
       ),
     });
   }

--- a/lib/authenticated-rest-api/authenticated-rest-api-function-props.ts
+++ b/lib/authenticated-rest-api/authenticated-rest-api-function-props.ts
@@ -13,4 +13,5 @@ export interface AuthenticatedRestApiFunctionProps {
   securityGroups?: Array<ec2.ISecurityGroup>;
   memorySize?: number;
   bundling?: BundlingOptions;
+  runtime: cdk.aws_lambda.Runtime;
 }

--- a/lib/authenticated-rest-api/authenticated-rest-api-function.ts
+++ b/lib/authenticated-rest-api/authenticated-rest-api-function.ts
@@ -12,11 +12,11 @@ export class AuthenticatedRestApiFunction extends lambdaNode.NodejsFunction {
   constructor(
     scope: Construct,
     id: string,
-    props: AuthenticatedRestApiFunctionProps,
+    props: AuthenticatedRestApiFunctionProps
   ) {
     if (props.memorySize && props.memorySize < MINIMUM_MEMORY_SIZE) {
       cdk.Annotations.of(scope).addError(
-        `lambda memory of ${props.memorySize} is less than the recommended size of ${MINIMUM_MEMORY_SIZE}`,
+        `lambda memory of ${props.memorySize} is less than the recommended size of ${MINIMUM_MEMORY_SIZE}`
       );
     }
 
@@ -32,7 +32,7 @@ export class AuthenticatedRestApiFunction extends lambdaNode.NodejsFunction {
 
       // Enforce the following properties
       awsSdkConnectionReuse: true,
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: props.runtime,
       timeout: props.timeout,
       securityGroups: props.securityGroups,
       vpc: props.vpc,

--- a/lib/authenticated-rest-api/authenticated-rest-api.ts
+++ b/lib/authenticated-rest-api/authenticated-rest-api.ts
@@ -33,7 +33,7 @@ export class AuthenticatedRestApi extends Construct {
       certificate: acm.Certificate.fromCertificateArn(
         this,
         "cert",
-        props.certificateArn,
+        props.certificateArn
       ),
     });
     const apiName = `${props.prefix}${props.name}`;
@@ -114,12 +114,12 @@ export class AuthenticatedRestApi extends Construct {
         }),
 
         awsSdkConnectionReuse: true,
-        runtime: lambda.Runtime.NODEJS_18_X,
+        runtime: lambda.Runtime.NODEJS_22_X,
         timeout: authLambdaTimeout,
         securityGroups: props.securityGroups,
         vpc: props.vpc,
         vpcSubnets: props.vpcSubnets,
-      },
+      }
     );
 
     const authorizer = new apigateway.TokenAuthorizer(
@@ -128,7 +128,7 @@ export class AuthenticatedRestApi extends Construct {
       {
         handler: authLambda,
         resultsCacheTtl: cdk.Duration.seconds(0),
-      },
+      }
     );
 
     if (props.resourceProps) {
@@ -160,7 +160,7 @@ export class AuthenticatedRestApi extends Construct {
         // Set treatMissingData to IGNORE
         // Stops alarms with minimal data having false alarms when they transition to this state
         treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-      },
+      }
     );
     routeLatencyAlarm.addAlarmAction(this.alarmAction);
     routeLatencyAlarm.addOkAction(this.alarmAction);
@@ -170,16 +170,16 @@ export class AuthenticatedRestApi extends Construct {
     apiName: string,
     resourceProps: ResourceProps,
     authorizer: apigateway.IAuthorizer,
-    parent?: apigateway.Resource,
+    parent?: apigateway.Resource
   ) {
     const actualParent = parent ?? this.restApi.root;
 
     const resource: apigateway.Resource = actualParent.addResource(
-      resourceProps.name,
+      resourceProps.name
     );
     for (const method in resourceProps.methods) {
       const integration = new apigateway.LambdaIntegration(
-        resourceProps.methods[method].function,
+        resourceProps.methods[method].function
       );
       if (resourceProps.methods[method].isPublic === true) {
         resource.addMethod(method, integration, {
@@ -221,7 +221,7 @@ export class AuthenticatedRestApi extends Construct {
           // Set treatMissingData to IGNORE
           // Stops alarms with minimal data having false alarms when they transition to this state
           treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-        },
+        }
       );
       durationAlarm.addAlarmAction(this.alarmAction);
       durationAlarm.addOkAction(this.alarmAction);
@@ -245,14 +245,14 @@ export class AuthenticatedRestApi extends Construct {
           // Set treatMissingData to IGNORE
           // Stops alarms with minimal data having false alarms when they transition to this state
           treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-        },
+        }
       );
       errorsAlarm.addAlarmAction(this.alarmAction);
       errorsAlarm.addOkAction(this.alarmAction);
     }
 
     resourceProps.nestedResources?.map((nestedResource) =>
-      this.addResource(apiName, nestedResource, authorizer, resource),
+      this.addResource(apiName, nestedResource, authorizer, resource)
     );
   }
 }

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -21,6 +21,7 @@ export interface FunctionLambdaProps
   entry: string;
   /** @default true */
   awsSdkConnectionReuse?: boolean;
+  runtime: lambda.Runtime;
 }
 
 export interface ContainerFromEcrLambdaProps {

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -46,7 +46,7 @@ export class LambdaWorker extends Construct {
     // Lambda settings
     if (props.lambdaProps.memorySize < MINIMUM_MEMORY_SIZE) {
       throw new Error(
-        `Invalid lambdaProps.memorySize value of ${props.lambdaProps.memorySize}. Minimum value is ${MINIMUM_MEMORY_SIZE}`,
+        `Invalid lambdaProps.memorySize value of ${props.lambdaProps.memorySize}. Minimum value is ${MINIMUM_MEMORY_SIZE}`
       );
     }
 
@@ -54,13 +54,13 @@ export class LambdaWorker extends Construct {
       props.lambdaProps.timeout.toSeconds() < MINIMUM_LAMBDA_TIMEOUT.toSeconds()
     ) {
       throw new Error(
-        `Invalid lambdaProps.timeout value of ${props.lambdaProps.timeout.toSeconds()}. Minimum value is ${MINIMUM_LAMBDA_TIMEOUT.toSeconds()}`,
+        `Invalid lambdaProps.timeout value of ${props.lambdaProps.timeout.toSeconds()}. Minimum value is ${MINIMUM_LAMBDA_TIMEOUT.toSeconds()}`
       );
     }
 
     if (!this.isContainerLambda(props) && !this.isFunctionLambda(props)) {
       throw new Error(
-        `Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified.`,
+        `Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified.`
       );
     }
 
@@ -71,7 +71,7 @@ export class LambdaWorker extends Construct {
         : DEFAULT_MAX_RECEIVE_COUNT;
 
     const queueTimeout = cdk.Duration.seconds(
-      maxReceiveCount * props.lambdaProps.timeout.toSeconds(),
+      maxReceiveCount * props.lambdaProps.timeout.toSeconds()
     );
 
     const approximateAgeOfOldestMessageThreshold =
@@ -128,7 +128,7 @@ export class LambdaWorker extends Construct {
       }
 
       props.subscription.topic.addSubscription(
-        new subs.SqsSubscription(this.lambdaQueue, subscriptionProps),
+        new subs.SqsSubscription(this.lambdaQueue, subscriptionProps)
       );
     }
 
@@ -149,14 +149,14 @@ export class LambdaWorker extends Construct {
         enabled: props.lambdaProps.enableQueue ?? true,
         batchSize: 1,
         maxConcurrency: props.lambdaProps.queueMaxConcurrency,
-      }),
+      })
     );
     lambdaWorker.addEventSource(
       new SqsEventSource(lambdaDLQ, {
         enabled: false,
         batchSize: 1,
         maxConcurrency: props.lambdaProps.queueMaxConcurrency,
-      }),
+      })
     );
 
     // Add alerting
@@ -185,7 +185,7 @@ export class LambdaWorker extends Construct {
         // Set treatMissingData to IGNORE
         // Stops alarms with minimal data having false alarms when they transition to this state
         treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-      },
+      }
     );
     dlqMessagesVisable.addAlarmAction(alarmAction);
     dlqMessagesVisable.addOkAction(alarmAction);
@@ -209,7 +209,7 @@ export class LambdaWorker extends Construct {
         // Set treatMissingData to IGNORE
         // Stops alarms with minimal data having false alarms when they transition to this state
         treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-      },
+      }
     );
     queueMessagesAge.addAlarmAction(alarmAction);
     queueMessagesAge.addOkAction(alarmAction);
@@ -230,7 +230,7 @@ export class LambdaWorker extends Construct {
         // Set treatMissingData to IGNORE
         // Stops alarms with minimal data having false alarms when they transition to this state
         treatMissingData: cloudwatch.TreatMissingData.IGNORE,
-      },
+      }
     );
     queueMessagesVisable.addAlarmAction(alarmAction);
     queueMessagesVisable.addOkAction(alarmAction);
@@ -268,7 +268,7 @@ export class LambdaWorker extends Construct {
       props.lambdaProps.imageAsset ||
         (props.lambdaProps.dockerImageTag &&
           props.lambdaProps.ecrRepositoryArn &&
-          props.lambdaProps.ecrRepositoryName),
+          props.lambdaProps.ecrRepositoryName)
     );
   }
 
@@ -277,7 +277,7 @@ export class LambdaWorker extends Construct {
   }
 
   private createNodejsLambdaFunction(
-    props: LambdaWorkerProps,
+    props: LambdaWorkerProps
   ): lambda.Function {
     return new lambdaNodeJs.NodejsFunction(this, props.name, {
       functionName: props.name,
@@ -303,7 +303,7 @@ export class LambdaWorker extends Construct {
       // NodejsFunction-only props
       entry: props.lambdaProps.entry,
       handler: props.lambdaProps.handler,
-      runtime: props.lambdaProps.runtime ?? lambda.Runtime.NODEJS_18_X,
+      runtime: props.lambdaProps.runtime,
       awsSdkConnectionReuse: props.lambdaProps.awsSdkConnectionReuse ?? true,
       depsLockFilePath: props.lambdaProps.depsLockFilePath,
       bundling: props.lambdaProps.bundling,
@@ -312,7 +312,7 @@ export class LambdaWorker extends Construct {
   }
 
   private createContainerLambdaFunction(
-    props: LambdaWorkerProps,
+    props: LambdaWorkerProps
   ): lambda.Function {
     return new lambda.DockerImageFunction(this, props.name, {
       code: this.getContainerLambdaCode(props),
@@ -336,12 +336,12 @@ export class LambdaWorker extends Construct {
   }
 
   private getContainerLambdaCode(
-    props: LambdaWorkerProps,
+    props: LambdaWorkerProps
   ): lambda.DockerImageCode {
     if (props.lambdaProps.imageAsset) {
       return lambda.DockerImageCode.fromImageAsset(
         props.lambdaProps.imageAsset.directory,
-        props.lambdaProps.imageAsset.props,
+        props.lambdaProps.imageAsset.props
       );
     }
 

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -273,7 +273,11 @@ export class LambdaWorker extends Construct {
   }
 
   private hasFunctionLambdaProps(props: LambdaWorkerProps): boolean {
-    return Boolean(props.lambdaProps.entry && props.lambdaProps.handler);
+    return Boolean(
+      props.lambdaProps.entry &&
+        props.lambdaProps.handler &&
+        props.lambdaProps.runtime
+    );
   }
 
   private createNodejsLambdaFunction(

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.162.0",
+        "aws-cdk-lib": "^2.200.1",
         "constructs": "^10.0.0"
       }
     },
@@ -61,15 +61,10 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.206",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.206.tgz",
-      "integrity": "sha512-l2eAROXoPOXNyXt3lGUEveHo/U8c0IX7RTjgf2qy1LcZw6IkUIIIy/erQ6bBqZ5SibRfFAoXSBBC+gFfGyZDcA==",
-      "peer": true
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.2.237",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.237.tgz",
+      "integrity": "sha512-OlXylbXI52lboFVJBFLae+WB99qWmI121x/wXQHEMj2RaVNVbWE+OAHcDk2Um1BitUQCaTf9ki57B0Fuqx0Rvw==",
+      "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -79,17 +74,21 @@
       "peer": true
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "38.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
-      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "version": "44.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-44.2.0.tgz",
+      "integrity": "sha512-oB3fq8yudGMHsSOyh2rFge5HVUMS6MOiAqK/6a9pyG4kHPkza0xCPlpvLFVCliD8y/VrsfxIcA584x9O0cxDiQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.6.3"
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -102,7 +101,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.2",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -3120,9 +3119,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.162.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.162.0.tgz",
-      "integrity": "sha512-Mx/8N9w+yqQONsGIFFk9Rl0JOu9nNWpU+JLlr73mHvhwxzhCT2XEZnS98UUiwuAcJYwl0c2Eh32joxj/txh3JA==",
+      "version": "2.200.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.200.1.tgz",
+      "integrity": "sha512-kLeDtMJPYX3qSAGPONNa3XZk8Z/K3d0As8ui10/Hbv0ohsEsphxSy0xRoxdyj58/hGxOwj1TZsBezMp+TuPPrg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3136,22 +3135,22 @@
         "yaml",
         "mime-types"
       ],
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-awscli-v1": "2.2.237",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^44.1.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "^11.3.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.3",
-        "table": "^6.8.2",
+        "semver": "^7.7.2",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -3278,13 +3277,23 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.1",
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "inBundle": true,
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -3340,7 +3349,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -3406,7 +3415,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.2",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -3461,7 +3470,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -5292,7 +5301,6 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5531,8 +5539,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -6965,7 +6972,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -11720,7 +11726,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -12589,7 +12594,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.162.0",
+    "aws-cdk-lib": "^2.200.1",
     "constructs": "^10.0.0"
   }
 }

--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -22,6 +22,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -38,6 +39,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -54,6 +56,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -70,6 +73,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -86,6 +90,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -102,6 +107,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -118,6 +124,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -134,6 +141,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -150,6 +158,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -166,6 +175,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -182,6 +192,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -198,6 +209,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -214,6 +226,7 @@
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -230,6 +243,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -246,6 +260,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -262,6 +277,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -278,6 +294,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -294,6 +311,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -310,6 +328,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -326,6 +345,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -342,6 +362,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -358,6 +379,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -374,6 +396,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -385,12 +408,14 @@
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -406,6 +431,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -414,6 +440,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -421,12 +448,14 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -434,12 +463,14 @@
     "node_modules/aws4": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -447,12 +478,14 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/cache-service": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cache-service/-/cache-service-1.3.5.tgz",
       "integrity": "sha512-3fJgrsT1RDW+pBxy7ag2FkU1rm1e4hJc1bKH9Gj4C7vin9+L3KacMHHBDTeKG4g3mDp5ohZBwS0nckpn/b1ufA==",
+      "license": "MIT",
       "dependencies": {
         "cache-service-cache-module": "1.2.3"
       }
@@ -460,12 +493,14 @@
     "node_modules/cache-service-cache-module": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cache-service-cache-module/-/cache-service-cache-module-1.2.3.tgz",
-      "integrity": "sha512-4UmGgSp8aOoNf/7qANi6vn5BGDSCKLU/NI9ys4zlUoaIi2J6zuQhIOYtoKS4hntRjVqGXe39Yyx1fhHBZDYrTg=="
+      "integrity": "sha512-4UmGgSp8aOoNf/7qANi6vn5BGDSCKLU/NI9ys4zlUoaIi2J6zuQhIOYtoKS4hntRjVqGXe39Yyx1fhHBZDYrTg==",
+      "license": "MIT"
     },
     "node_modules/cache-service-node-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cache-service-node-cache/-/cache-service-node-cache-2.0.0.tgz",
       "integrity": "sha512-F9L8LqtR2Pt5yBFxGma8BCEJVVbZKARLZMHcJAdfUFLP5Ulavn7OVL9fGQUv2sQpU6DMm5SLZgqHaudxBEV3uQ==",
+      "license": "MIT",
       "peerDependencies": {
         "node-cache": ">=2.1.1"
       }
@@ -481,12 +516,14 @@
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
@@ -495,6 +532,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -503,6 +541,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -511,6 +550,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -521,12 +561,14 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
     },
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
@@ -540,6 +582,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -548,9 +591,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -567,6 +611,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -575,6 +620,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
       "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
       }
@@ -583,6 +629,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -592,6 +639,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -602,6 +650,7 @@
       "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -637,7 +686,8 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -645,22 +695,26 @@
       "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -669,6 +723,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -682,6 +737,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -690,6 +746,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
@@ -699,6 +756,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -711,6 +769,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -722,9 +781,10 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.29.1.tgz",
-      "integrity": "sha512-iq4u3AC9h9/P/gBXH1cUR7Ln0exKexqMaYDwUaoZJzkvvgJs9W5+CLQFS0APyG8uyvJJjn6q6Vx7LwmZQu3h5A==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.30.0.tgz",
+      "integrity": "sha512-P9F4Eo6zicYsIJbEy/mPJmSxKY0rVcmiy5H8oXPxPDotQRCvCBjBuI5QWoQQanVE9jdeocnum5iqYAHl4pHdLA==",
+      "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "^1.0.2",
         "cluster-key-slot": "^1.1.0",
@@ -749,42 +809,50 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/jsonwebtoken": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
       "integrity": "sha512-VP2HXX7tJ73v5ZGGTFdgILhOBwGSDlPP4qArdrq6YbDVJ9YJflcNE/fbuGHPlefPkbM1+7rFzz1eTq1xICsJxA==",
+      "license": "MIT",
       "dependencies": {
         "jws": "^3.0.0",
         "ms": "^0.7.1",
@@ -797,12 +865,14 @@
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-      "integrity": "sha512-lrKNzMWqQZgwJahtrtrM+9NgOoDUveDrVmm5aGXrf3BdtL0mq7X6IVzoZaw+TfNti29eHd1/8GI+h45K5cQ6/w=="
+      "integrity": "sha512-lrKNzMWqQZgwJahtrtrM+9NgOoDUveDrVmm5aGXrf3BdtL0mq7X6IVzoZaw+TfNti29eHd1/8GI+h45K5cQ6/w==",
+      "license": "MIT"
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -814,11 +884,12 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -827,6 +898,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -835,27 +907,32 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",
@@ -866,6 +943,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -874,6 +952,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -884,12 +963,14 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-cache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
       "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
+      "license": "MIT",
       "dependencies": {
         "clone": "2.x",
         "lodash": "4.x"
@@ -902,6 +983,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -910,6 +992,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -917,12 +1000,14 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -934,6 +1019,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -941,12 +1027,14 @@
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
@@ -955,6 +1043,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -963,6 +1052,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -975,6 +1065,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1005,6 +1096,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.19"
       },
@@ -1020,6 +1112,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "license": "ISC",
       "dependencies": {
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
@@ -1037,6 +1130,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -1058,17 +1152,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1092,12 +1189,14 @@
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1124,6 +1223,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -1136,6 +1236,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -1146,12 +1247,14 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -1160,6 +1263,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1168,7 +1272,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
       "integrity": "sha512-BooSif/UQWXwaQme+4z32duvmtUUz/nlHsyGrrSCgsGf6snMrp9q/n1nGHwQzU12kaCeceODmAiRZA8TCK06jA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT"
     },
     "node_modules/verror": {
       "version": "1.10.0",
@@ -1177,6 +1282,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -1187,6 +1293,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }

--- a/test/infra/authenticated-api/authenticated-api.test.ts
+++ b/test/infra/authenticated-api/authenticated-api.test.ts
@@ -31,10 +31,11 @@ describe("AuthenticatedApi", () => {
           entry: `${path.resolve(__dirname)}/routes/route1.js`,
           environment: {},
           handler: "route",
+          runtime: lambda.Runtime.NODEJS_22_X,
           timeout: cdk.Duration.seconds(30),
           securityGroups: [],
           vpc: vpc,
-        },
+        }
       );
 
       const route2Handler = new AuthenticatedApiFunction(
@@ -57,7 +58,7 @@ describe("AuthenticatedApi", () => {
           bundling: {
             minify: true,
           },
-        },
+        }
       );
 
       new AuthenticatedApi(stack, "MyTestAuthenticatedApi", {
@@ -118,7 +119,7 @@ describe("AuthenticatedApi", () => {
               `https://test-simple-authenticated-api.talis.com`,
             ],
           },
-        },
+        }
       );
     });
 
@@ -130,14 +131,14 @@ describe("AuthenticatedApi", () => {
         {
           RouteKey: "GET /1/test-route-1",
           AuthorizationType: "CUSTOM",
-        },
+        }
       );
       Template.fromStack(stack).hasResourceProperties(
         "AWS::ApiGatewayV2::Route",
         {
           RouteKey: "GET /1/test-route-2",
           AuthorizationType: "NONE",
-        },
+        }
       );
     });
 
@@ -148,7 +149,7 @@ describe("AuthenticatedApi", () => {
         FunctionName: "test-MyTestAuthenticatedApi-authoriser",
         Timeout: 120,
         Handler: "index.validateToken",
-        Runtime: "nodejs18.x",
+        Runtime: "nodejs22.x",
         Environment: {
           Variables: {
             PERSONA_CLIENT_NAME: "test-MyTestAuthenticatedApi-authoriser",
@@ -169,7 +170,7 @@ describe("AuthenticatedApi", () => {
         FunctionName: "test-route1-handler",
         Timeout: 30,
         Handler: "index.route",
-        Runtime: "nodejs18.x",
+        Runtime: "nodejs22.x",
         Environment: {
           Variables: {
             LAMBDA_EXECUTION_TIMEOUT: "30",
@@ -217,7 +218,7 @@ describe("AuthenticatedApi", () => {
           ComparisonOperator: "GreaterThanOrEqualToThreshold",
           TreatMissingData: "ignore",
           OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-        },
+        }
       );
     });
 
@@ -244,7 +245,7 @@ describe("AuthenticatedApi", () => {
           ComparisonOperator: "GreaterThanOrEqualToThreshold",
           TreatMissingData: "ignore",
           OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-        },
+        }
       );
 
       Template.fromStack(stack).hasResourceProperties(
@@ -269,7 +270,7 @@ describe("AuthenticatedApi", () => {
           ComparisonOperator: "GreaterThanOrEqualToThreshold",
           TreatMissingData: "ignore",
           OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-        },
+        }
       );
     });
 
@@ -296,7 +297,7 @@ describe("AuthenticatedApi", () => {
           ComparisonOperator: "GreaterThanOrEqualToThreshold",
           TreatMissingData: "ignore",
           OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-        },
+        }
       );
 
       Template.fromStack(stack).hasResourceProperties(
@@ -321,7 +322,7 @@ describe("AuthenticatedApi", () => {
           ComparisonOperator: "GreaterThanOrEqualToThreshold",
           TreatMissingData: "ignore",
           OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-        },
+        }
       );
     });
   });
@@ -387,14 +388,14 @@ describe("AuthenticatedApi", () => {
         {
           RouteKey: "GET /api/index.html",
           AuthorizationType: "NONE",
-        },
+        }
       );
       Template.fromStack(stack).hasResourceProperties(
         "AWS::ApiGatewayV2::Route",
         {
           RouteKey: "GET /docs/index.html",
           AuthorizationType: "NONE",
-        },
+        }
       );
     });
   });
@@ -462,10 +463,10 @@ describe("AuthenticatedApi", () => {
               ],
             },
             Format: Match.stringLikeRegexp(
-              '{\\"requestId":\\"\\$context.requestId\\",*',
+              '{\\"requestId":\\"\\$context.requestId\\",*'
             ),
           },
-        },
+        }
       );
     });
 
@@ -500,7 +501,7 @@ describe("AuthenticatedApi", () => {
             },
             Format: apacheLikeFormat,
           },
-        },
+        }
       );
     });
 

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -39,6 +39,7 @@ describe("LambdaWorker", () => {
                 resources: ["*"],
               }),
             ],
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.minutes(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -57,14 +58,14 @@ describe("LambdaWorker", () => {
             MemorySize: 2048,
             Timeout: 300,
             Handler: "index.testWorker",
-            Runtime: "nodejs18.x",
+            Runtime: "nodejs22.x",
             Environment: {
               Variables: {
                 AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
                 LAMBDA_EXECUTION_TIMEOUT: "300",
               },
             },
-          },
+          }
         );
       });
 
@@ -116,7 +117,7 @@ describe("LambdaWorker", () => {
             ScalingConfig: {
               MaximumConcurrency: 5,
             },
-          },
+          }
         );
 
         Template.fromStack(stack).hasResourceProperties(
@@ -127,7 +128,7 @@ describe("LambdaWorker", () => {
             ScalingConfig: {
               MaximumConcurrency: 5,
             },
-          },
+          }
         );
       });
 
@@ -161,7 +162,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
 
@@ -191,7 +192,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
 
@@ -221,7 +222,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
     });
@@ -250,6 +251,7 @@ describe("LambdaWorker", () => {
             timeout: cdk.Duration.minutes(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+            runtime: lambda.Runtime.NODEJS_22_X,
 
             // Optional
             description: "Test Description",
@@ -274,7 +276,7 @@ describe("LambdaWorker", () => {
             MemorySize: 2048,
             Timeout: 300,
             Handler: "index.testWorker",
-            Runtime: "nodejs18.x",
+            Runtime: "nodejs22.x",
             //Optional
             Description: "Test Description",
             Environment: {
@@ -287,7 +289,7 @@ describe("LambdaWorker", () => {
               Size: 1024,
             },
             ReservedConcurrentExecutions: 10,
-          },
+          }
         );
       });
     });
@@ -314,7 +316,7 @@ describe("LambdaWorker", () => {
             handler: "testWorker",
             projectRoot: path.resolve(
               __dirname,
-              "../../../examples/simple-lambda-worker",
+              "../../../examples/simple-lambda-worker"
             ),
             depsLockFilePath: "examples/simple-lambda-worker/package-lock.json",
             runtime: lambda.Runtime.NODEJS_20_X,
@@ -341,7 +343,7 @@ describe("LambdaWorker", () => {
             Handler: "index.testWorker",
             Runtime: "nodejs20.x",
             Environment: { Variables: { LAMBDA_EXECUTION_TIMEOUT: "300" } },
-          },
+          }
         );
       });
     });
@@ -370,6 +372,7 @@ describe("LambdaWorker", () => {
             entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
             handler: "testWorker",
             memorySize: 2048,
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.minutes(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -398,7 +401,7 @@ describe("LambdaWorker", () => {
                 "Arn",
               ],
             },
-          },
+          }
         );
       });
     });
@@ -427,6 +430,7 @@ describe("LambdaWorker", () => {
             entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
             handler: "testWorker",
             memorySize: 2048,
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.minutes(5),
             enableQueue: false,
             vpc: vpc,
@@ -444,7 +448,7 @@ describe("LambdaWorker", () => {
         Template.fromStack(stack).resourceCountIs("AWS::Lambda::Function", 1);
         Template.fromStack(stack).resourceCountIs(
           "AWS::Lambda::EventSourceMapping",
-          2,
+          2
         );
 
         Template.fromStack(stack).hasResourceProperties(
@@ -460,7 +464,7 @@ describe("LambdaWorker", () => {
                 "Arn",
               ],
             },
-          },
+          }
         );
       });
     });
@@ -489,6 +493,7 @@ describe("LambdaWorker", () => {
             entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
             handler: "testWorker",
             memorySize: 2048,
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.minutes(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -505,7 +510,7 @@ describe("LambdaWorker", () => {
         Template.fromStack(stack).resourceCountIs("AWS::Lambda::Function", 1);
         Template.fromStack(stack).resourceCountIs(
           "AWS::Lambda::EventSourceMapping",
-          2,
+          2
         );
 
         Template.fromStack(stack).hasResourceProperties(
@@ -524,7 +529,7 @@ describe("LambdaWorker", () => {
             ScalingConfig: {
               MaximumConcurrency: 5,
             },
-          },
+          }
         );
       });
     });
@@ -558,6 +563,7 @@ describe("LambdaWorker", () => {
               resources: ["*"],
             }),
           ],
+          runtime: lambda.Runtime.NODEJS_22_X,
           timeout: cdk.Duration.minutes(5),
           vpc: vpc,
           vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -665,7 +671,7 @@ describe("LambdaWorker", () => {
                 ],
               },
             },
-          },
+          }
         );
       });
 
@@ -736,7 +742,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
 
@@ -766,7 +772,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
 
@@ -796,7 +802,7 @@ describe("LambdaWorker", () => {
             ComparisonOperator: "GreaterThanOrEqualToThreshold",
             TreatMissingData: "ignore",
             OKActions: [{ Ref: "TestAlarm5A9EF6BD" }],
-          },
+          }
         );
       });
     });
@@ -870,7 +876,7 @@ describe("LambdaWorker", () => {
                 ],
               },
             },
-          },
+          }
         );
       });
     });
@@ -931,7 +937,7 @@ describe("LambdaWorker", () => {
                   "${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-${AWS::AccountId}-${AWS::Region}:4cf46eba6932d8b82d75ff231d64f6eb5c2c8a5b843e7100222cab515bd5e5f2",
               },
             },
-          },
+          }
         );
       });
 
@@ -971,7 +977,7 @@ describe("LambdaWorker", () => {
             ImageConfig: {
               Command: ["app.handler"],
             },
-          },
+          }
         );
       });
     });
@@ -997,6 +1003,7 @@ describe("LambdaWorker", () => {
             entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
             handler: "testWorker",
             memorySize: 2048,
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.seconds(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -1028,6 +1035,7 @@ describe("LambdaWorker", () => {
             entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
             handler: "testWorker",
             memorySize: 512,
+            runtime: lambda.Runtime.NODEJS_22_X,
             timeout: cdk.Duration.minutes(5),
             vpc: vpc,
             vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -1036,7 +1044,7 @@ describe("LambdaWorker", () => {
           alarmTopic: alarmTopic,
         });
       }).toThrow(
-        "Invalid lambdaProps.memorySize value of 512. Minimum value is 1024",
+        "Invalid lambdaProps.memorySize value of 512. Minimum value is 1024"
       );
     });
   });
@@ -1143,6 +1151,7 @@ describe("LambdaWorker", () => {
               ecrRepositoryArn: config.ecrRepositoryArn,
               ecrRepositoryName: config.ecrRepositoryName,
               memorySize: 2048,
+              runtime: lambda.Runtime.NODEJS_22_X,
               timeout: cdk.Duration.minutes(5),
               vpc: vpc,
               vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
@@ -1151,7 +1160,7 @@ describe("LambdaWorker", () => {
             alarmTopic: alarmTopic,
           });
         }).toThrow(
-          "Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified.",
+          "Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified."
         );
       });
     });


### PR DESCRIPTION
- PLT-1660

Updates the constructs to make the lambda runtime a required property instead of optional and no longer hardcode this within the constructs instead requiring the end user to specify this.

Updates the authenticated API authorizer lambda to use Node 22 runtime.