### PR TITLE
feat: plt-1759 add optional queue timeout property to lambda worker

### DIFF
--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -60,6 +60,7 @@ export interface LambdaWorkerProps {
     vpc?: ec2.IVpc;
     vpcSubnets?: ec2.SubnetSelection;
     queueMaxConcurrency: number;
+    queueTimeout?: cdk.Duration;
   } & Partial<FunctionLambdaProps> &
     Partial<ContainerFromEcrLambdaProps> &
     Partial<ContainerFromImageAssetLambdaProps>;

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -63,7 +63,6 @@ export class LambdaWorker extends Construct {
         `Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified.`,
       );
     }
-    
 
     // Queue settings
     const maxReceiveCount =
@@ -71,9 +70,11 @@ export class LambdaWorker extends Construct {
         ? props.queueProps.maxReceiveCount
         : DEFAULT_MAX_RECEIVE_COUNT;
 
-    const queueTimeout = props.lambdaProps.queueTimeout ? props.lambdaProps.queueTimeout : cdk.Duration.seconds(
-      maxReceiveCount * props.lambdaProps.timeout.toSeconds(),
-    );
+    const queueTimeout = props.lambdaProps.queueTimeout
+      ? props.lambdaProps.queueTimeout
+      : cdk.Duration.seconds(
+          maxReceiveCount * props.lambdaProps.timeout.toSeconds(),
+        );
 
     const approximateAgeOfOldestMessageThreshold =
       props.queueProps &&

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -63,6 +63,7 @@ export class LambdaWorker extends Construct {
         `Invalid lambdaProps only dockerImageTag/ecrRepositoryArn/ecrRepositoryName or handler/entry can be specified.`,
       );
     }
+    
 
     // Queue settings
     const maxReceiveCount =
@@ -70,7 +71,7 @@ export class LambdaWorker extends Construct {
         ? props.queueProps.maxReceiveCount
         : DEFAULT_MAX_RECEIVE_COUNT;
 
-    const queueTimeout = cdk.Duration.seconds(
+    const queueTimeout = props.lambdaProps.queueTimeout ? props.lambdaProps.queueTimeout : cdk.Duration.seconds(
       maxReceiveCount * props.lambdaProps.timeout.toSeconds(),
     );
 

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -260,6 +260,7 @@ describe("LambdaWorker", () => {
               TALIS_ENV_VAR: "some value",
             },
             reservedConcurrentExecutions: 10,
+            queueTimeout: cdk.Duration.seconds(90),
           },
           queueProps: {},
           alarmTopic: alarmTopic,
@@ -291,6 +292,20 @@ describe("LambdaWorker", () => {
             ReservedConcurrentExecutions: 10,
           },
         );
+      });
+
+      test("provisions a queue with the specified queueTimeout", () => {
+        Template.fromStack(stack).resourceCountIs("AWS::SQS::Queue", 2);
+
+        Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+          QueueName: "MyTestLambdaWorker-queue",
+          VisibilityTimeout: 90,
+        });
+
+        Template.fromStack(stack).hasResourceProperties("AWS::SQS::Queue", {
+          QueueName: "MyTestLambdaWorker-dlq",
+          VisibilityTimeout: 90,
+        });
       });
     });
 


### PR DESCRIPTION
- https://techfromsage.atlassian.net/browse/PLT-1759

## Summary 

This PR allows the overriding of the default value of the Lambda Workers queueTimeout property. 

## History

To fix issues at scale with triggering lambda's from SQS, the lambda worker previously enforced a queue timeout following guidelines described here:

- https://zaccharles.medium.com/lambda-concurrency-limits-and-sqs-triggers-dont-mix-well-sometimes-eb23d90122e0

AWS later provided a fix for this issue, the setting of a `maxConcurrency` setting described here:

- https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/

`maxConcurrency` was made a **MANDATORY** property on LambdaWorker in PR:
 - https://github.com/techfromsage/talis-cdk-constructs/pull/86

## Changes

This PR allows the overriding of the default value of the Lambda Workers queueTimeout property. 

It is **NOT** compulsory, so it is not a breaking change. Applications using this construct which do not set the new optional `queueTimeout` property will still use the timeout calculated following the guidelines from the [blogpost](https://zaccharles.medium.com/lambda-concurrency-limits-and-sqs-triggers-dont-mix-well-sometimes-eb23d90122e0).

However, as we have already made `maxConcurrency` a mandatory setting in [this](https://github.com/techfromsage/talis-cdk-constructs/pull/86) PR, we are already enforcing that applications use this feature to control concurrency and therefore mitigate the problems described in the blog post and seen in our apps.

As apps are forced to use `maxConcurrency` we are now allowing them to set a `queueTimeout`. By keeping the previously calculated figure if the new property is not set, apps upgrading this library will see no change unless they start setting the new property.

 
